### PR TITLE
Tag roles

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,23 +1,35 @@
 let TRIGGER_INTERVAL = 10; // in minutes
-let MANGADEX_RSS = "https://mangadex.org/rss/link"; // Paste here your RSS link
+let MANGADEX_RSS = "https://mangadex.org/rss/your-rss"; // Paste here your RSS link
 let WEBHOOK_NAME = "MangaDex"; // Name that the webhook will use
 let AVATAR_URL = "https://mangadex.org/images/misc/default_brand.png?1"; // Avatar that the webhook will use
 let WEBHOOKS_SHEET = "webhooks";
 let FILTERS_SHEET = "filters";
-let ROLES = "roles";
+let CURRENT_VERSION = "1.2";
+
+var isUpdated = true;
 
 function timerTrigger() {
   main();
 }
 
 function main() {
+  checkIfScriptIsUpdated();
   let mangas = getLatestMangas();
+  
+  if (!mangas) return;
   
   for (var i = 0; i < mangas.length; i++) {
     let manga = mangas[i];
     
     sendMangaToWebhook(manga);
   }
+}
+
+function checkIfScriptIsUpdated(){
+  let url = "https://api.github.com/repos/GuilhermeFaga/MangaDex-discord-webhook-with-Google-Script/releases"
+  let latestVersion = request(url, "GET")[0];
+  
+  if (latestVersion.name > CURRENT_VERSION) isUpdated = false;
 }
 
 function getLatestMangas(){
@@ -28,39 +40,65 @@ function getLatestMangas(){
   
   let regex = new RegExp(/<item>(.+?)<\/item>/sg);
   
-  let mangaWhitelist = getArrayFromSheets(FILTERS_SHEET);
+  let mangaWhitelist = getArrayFromSheets(FILTERS_SHEET, 1);
   
-  if (regex.test(response)){
-    let items = response.match(/<item>(.+?)<\/item>/sg);
-    var mangas = [];
-    items.map(function(item){
-      let manga = {
-        title: item.match(/<title>(.+?)<\/title>/s)[1],
-        link: item.match(/<link>(.+?)<\/link>/s)[1],
-        manga_link: item.match(/<mangaLink>(.+?)<\/mangaLink>/s)[1],
-        date: new Date(item.match(/<pubDate>(.+?)<\/pubDate>/s)[1]),
-        description: item.match(/<description>(.+?)<\/description>/s)[1].replace(/\s-\s/g, "\n"),
-        id: item.match(/<mangaLink>(.+?)<\/mangaLink>/s)[1].match(/title\/(.+)/)[1]
-      };
-      if (mangaIsNew(manga) && (!mangaWhitelist || mangaWhitelist.contains(manga.id))) {
-        var mangaDetails = request(mangaUrl + manga.id, "GET")["manga"];
-        manga["manga_title"] = mangaDetails["title"] ? mangaDetails["title"] : "";
-        manga["artist"] = mangaDetails["artist"] ? mangaDetails["artist"] : "";
-        manga["author"] = mangaDetails["author"] ? mangaDetails["author"] : "";
-        manga["lang"] = mangaDetails["lang_name"] ? mangaDetails["lang_name"] : "";
-        if (mangaDetails["links"])
-          manga["mal"] = mangaDetails["links"]["mal"] ? "https://myanimelist.net/manga/" + mangaDetails["links"]["mal"] : "";
-        manga["cover_url"] = mangaDetails["cover_url"] ? "https://mangadex.org" + mangaDetails["cover_url"] : "";
-        if (mangaDetails["rating"]){
-          manga["rating"] = mangaDetails["rating"]["bayesian"] ? mangaDetails["rating"]["bayesian"] : "";
-          manga["users"] = mangaDetails["rating"]["users"] ? mangaDetails["rating"]["users"] : "";
-        }
-        mangas.push(manga);
-      }
-    });
-    return mangas.reverse();
+  if (!regex.test(response)) return null;
+  
+  let items = response.match(/<item>(.+?)<\/item>/sg);
+  
+  var mangas = [];
+  for (let i = 0; i < items.length; i++) {
+    let item = items[i];
+    if (!item) continue;
+    
+    var manga = {
+      date:  new Date(item.match(/<pubDate>(.+?)<\/pubDate>/s)[1]),
+      manga_link: item.match(/<mangaLink>(.+?)<\/mangaLink>/s)[1],
+      id: item.match(/<mangaLink>(.+?)<\/mangaLink>/s)[1].match(/title\/(.+)/)[1]
+    };
+    
+    if (!(mangaIsNew(manga) && (!mangaWhitelist || mangaWhitelist.contains(manga.id)))) continue;
+    
+    var mangaDetails = request(mangaUrl + manga.id, "GET")["manga"];
+    manga["link"] = item.match(/<link>(.+?)<\/link>/s)[1];
+    manga["title"] = item.match(/<title>(.+?)<\/title>/s)[1];
+    
+    try {
+      manga["title"] = manga.title.match(/.+ - (.+)/)[1];
+    } catch (e) {
+      console.log(manga.title);
+      console.log(e);
+    }
+    
+    var isDuplicated = false;
+    
+    for (let j = 0; j < mangas.length; j++) {
+      const _manga = mangas[j];
+      if (_manga.id != manga.id) continue;
+      if (!_manga["chapters"]) _manga["chapters"] = [];
+      _manga["chapters"].push(`[${manga.title}](${manga.link})\n`);
+      //      _manga.description = `[${manga.title}](${manga.link})\n` + _manga.description;
+      isDuplicated = true;
+      break;
+    }
+    
+    if (isDuplicated) continue;
+    
+    manga["description"] = item.match(/<description>(.+?)<\/description>/s)[1].replace(/\s-\s/g, "\n");
+    manga["manga_title"] = mangaDetails["title"] ? mangaDetails["title"] : "";
+    manga["artist"] = mangaDetails["artist"] ? mangaDetails["artist"] : "";
+    manga["author"] = mangaDetails["author"] ? mangaDetails["author"] : "";
+    manga["lang"] = mangaDetails["lang_name"] ? mangaDetails["lang_name"] : "";
+    if (mangaDetails["links"])
+      manga["mal"] = mangaDetails["links"]["mal"] ? "https://myanimelist.net/manga/" + mangaDetails["links"]["mal"] : "";
+    manga["cover_url"] = mangaDetails["cover_url"] ? "https://mangadex.org" + mangaDetails["cover_url"] : "";
+    if (mangaDetails["rating"]){
+      manga["rating"] = mangaDetails["rating"]["bayesian"] ? mangaDetails["rating"]["bayesian"] : "";
+      manga["users"] = mangaDetails["rating"]["users"] ? mangaDetails["rating"]["users"] : "";
+    }
+    mangas.push(manga);
   }
-  return null;
+  return mangas.reverse();
 }
 
 function mangaIsNew(manga){
@@ -71,21 +109,22 @@ function mangaIsNew(manga){
 
 function sendMangaToWebhook(manga){
   
-  let webhooks = getArrayFromSheets(WEBHOOKS_SHEET);
-  let mangaWhitelist = getArrayFromSheets(ROLES);
+  let webhooks = getArrayFromSheets(WEBHOOKS_SHEET, 1);
+  
+  let mangaWhitelist = getArrayFromSheets(FILTERS_SHEET);
   
   var role = "";
-  for (var i = 0; i < mangaWhitelist.length; i++){
-    if(mangaWhitelist[i][0] == manga.id){
-      console.log(mangaWhitelist[i][1]);
-      role = mangaWhitelist[i][1];
+  if (mangaWhitelist) {
+    for (var i = 0; i < mangaWhitelist.length; i++){
+      if(mangaWhitelist[i][0] == manga.id && mangaWhitelist[i][1]){
+        role += "<@&" + mangaWhitelist[i][1] + ">";
       }
-     }
-  
-  console.log(webhooks);
+    }
+  }
   
   if (!webhooks) return;
   
+  var preDesc = "";
   var desc = "\n\n**------ Manga details ------**\n\n";
   
   if (manga["artist"]) desc += `**Artist:** ${manga.artist}\n`;
@@ -94,27 +133,22 @@ function sendMangaToWebhook(manga){
   if (manga["lang"]) desc += `**Language:** ${manga.lang}\n`;
   if (manga["mal"]) desc += `[View on MAL](${manga.mal})\n`;
   if (manga["rating"]) desc += `\n**Rating:** ${manga.rating} (${manga.users} reviews)`;
+  if (manga["chapters"]) preDesc = manga["chapters"].join("") + "\n";
   
-  let title;
-  
-  try {
-    title = manga.title.match(/.+ - (.+)/)[1];
-  } catch (e) {
-    title = manga.title;
-    console.log(manga.title);
-    console.log(e);
-  }
   
   let payload = {
     "embeds": [
       {
-        "title": title,
-        "description": manga.description + desc,
+        "title": manga.title,
+        "description": preDesc + manga.description + desc,
         "url": manga.link,
         "color": 16742144,
         "author": {
           "name": manga.manga_title,
           "url": manga.manga_link
+        },
+        "footer": {
+          "text": isUpdated ? "" : "New update available"
         },
         "timestamp": manga.date,
         "thumbnail": {

--- a/Code.gs
+++ b/Code.gs
@@ -1,6 +1,6 @@
 let TRIGGER_INTERVAL = 10; // in minutes
-let MANGADEX_RSS = "https://mangadex.org/rss/u2gfGAWPzqv8aSpcY4BM9XEtwyRZexD3"; // Paste here your RSS link
-let WEBHOOK_NAME = "MangaDex Bot"; // Name that the webhook will use
+let MANGADEX_RSS = "https://mangadex.org/rss/link"; // Paste here your RSS link
+let WEBHOOK_NAME = "MangaDex"; // Name that the webhook will use
 let AVATAR_URL = "https://mangadex.org/images/misc/default_brand.png?1"; // Avatar that the webhook will use
 let WEBHOOKS_SHEET = "webhooks";
 let FILTERS_SHEET = "filters";

--- a/Code.gs
+++ b/Code.gs
@@ -1,9 +1,10 @@
 let TRIGGER_INTERVAL = 10; // in minutes
-let MANGADEX_RSS = "https://mangadex.org/rss/your-rss"; // Paste here your RSS link
-let WEBHOOK_NAME = "MangaDex"; // Name that the webhook will use
+let MANGADEX_RSS = "https://mangadex.org/rss/u2gfGAWPzqv8aSpcY4BM9XEtwyRZexD3"; // Paste here your RSS link
+let WEBHOOK_NAME = "MangaDex Bot"; // Name that the webhook will use
 let AVATAR_URL = "https://mangadex.org/images/misc/default_brand.png?1"; // Avatar that the webhook will use
 let WEBHOOKS_SHEET = "webhooks";
 let FILTERS_SHEET = "filters";
+let ROLES = "roles";
 
 function timerTrigger() {
   main();
@@ -71,6 +72,15 @@ function mangaIsNew(manga){
 function sendMangaToWebhook(manga){
   
   let webhooks = getArrayFromSheets(WEBHOOKS_SHEET);
+  let mangaWhitelist = getArrayFromSheets(ROLES);
+  
+  var role = "";
+  for (var i = 0; i < mangaWhitelist.length; i++){
+    if(mangaWhitelist[i][0] == manga.id){
+      console.log(mangaWhitelist[i][1]);
+      role = mangaWhitelist[i][1];
+      }
+     }
   
   console.log(webhooks);
   
@@ -113,7 +123,8 @@ function sendMangaToWebhook(manga){
       }
     ],
     "username": WEBHOOK_NAME,
-    "avatar_url": AVATAR_URL
+    "avatar_url": AVATAR_URL,
+    "content": role
   };
   
   webhooks.map(webhook => request(webhook, "POST", payload));

--- a/helper.gs
+++ b/helper.gs
@@ -25,15 +25,17 @@ function request(url, method, payload, json = true){
   }
 }
 
-function getArrayFromSheets(sheetName) {
+function getArrayFromSheets(sheetName, columns = 0) {
   let ss = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
   let lastrow = ss.getLastRow();
   var values;
   try {
-    values = ss.getRange(1, 1, ss.getLastRow(), ss.getLastColumn()).getValues();
+    if (columns == 0) columns = ss.getLastColumn();
+    values = ss.getRange(1, 1, ss.getLastRow(), columns).getValues();
   } catch (e) {
     return null;  
   }
+  console.log(values);
   return values;
 }
 


### PR DESCRIPTION
Added in the ability to tag rolls, maybe as a separate branch.  The only _issue_ is that you now need a third sheet. For whatever reason if I added a second column to "filters" it just crashes the bot. The new sheet now has the format of [manga id] [role id].  

The purpose was in some larger servers people keep up on there manga in groups. Admins will assign rolls for those people.  This now allows the bot to do that magic and tag people when their favourite manga is out.